### PR TITLE
fix(mp4): read 64-bit atom sizes and reach a trailing moov

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10629,7 +10629,7 @@ dependencies = [
 
 [[package]]
 name = "rockbox-codecs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cc",
  "cpal",
@@ -10735,7 +10735,7 @@ dependencies = [
 
 [[package]]
 name = "rockbox-ffi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rockbox-codecs",
  "rockbox-dsp",
@@ -10901,7 +10901,7 @@ dependencies = [
 
 [[package]]
 name = "rockbox-metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "cpal",
@@ -10983,7 +10983,7 @@ dependencies = [
 
 [[package]]
 name = "rockbox-playback"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cpal",
  "quick-xml 0.37.5",

--- a/crates/rockbox-codecs/Cargo.toml
+++ b/crates/rockbox-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rockbox-codecs"
-version = "0.2.1"
+version = "0.2.2"
 description = "Rockbox audio decoders (FLAC, MP3, Vorbis, ALAC, WavPack, WAV/ADPCM, …) as a reusable decoding library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -65,7 +65,7 @@ mod = []
 [dependencies]
 # Provides get_metadata() (the codec_api id3 contract) at the C symbol
 # level and the public Metadata type re-exposed by Decoder::metadata().
-rockbox-metadata = { version = "0.1.0", path = "../rockbox-metadata" }
+rockbox-metadata = { version = "0.1.1", path = "../rockbox-metadata" }
 
 [build-dependencies]
 cc = "1"

--- a/crates/rockbox-codecs/vendor/lib/rbcodec/codecs/libm4a/demux.c
+++ b/crates/rockbox-codecs/vendor/lib/rbcodec/codecs/libm4a/demux.c
@@ -857,10 +857,25 @@ int qtmovie_read(stream_t *file, demux_res_t *demux_res)
             return 1;
         }
 
-        if (chunk_len == 1)
-            return 0;
-
         chunk_id = stream_read_uint32(qtmovie.stream);
+
+        if (chunk_len == 1)
+        {
+            /* The real length is a 64-bit value following the type field —
+             * common on mdat written by streaming encoders, which don't know
+             * the payload length up front. Every case below works in terms of
+             * "chunk_len - 8", and we have just consumed 8 extra header
+             * bytes, so normalise to the true length minus those 8.
+             */
+            uint64_t hi = stream_read_uint32(qtmovie.stream);
+            uint64_t lo = stream_read_uint32(qtmovie.stream);
+            uint64_t largesize = (hi << 32) | lo;
+
+            if (largesize < 16 || (largesize - 8) > (uint64_t) SIZE_MAX)
+                return 0;
+
+            chunk_len = (size_t) (largesize - 8);
+        }
 
         switch (chunk_id)
         {

--- a/crates/rockbox-ffi/Cargo.toml
+++ b/crates/rockbox-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rockbox-ffi"
-version = "0.3.1"
+version = "0.3.2"
 description = "Flat C ABI over rockbox-dsp + rockbox-metadata + rockbox-playback, for language bindings (Python, TypeScript, Elixir, Gleam, …)"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -25,9 +25,9 @@ default = ["player"]
 player = ["dep:rockbox-playback"]
 
 [dependencies]
-rockbox-codecs = { version = "0.2.1", path = "../rockbox-codecs" }
+rockbox-codecs = { version = "0.2.2", path = "../rockbox-codecs" }
 rockbox-dsp = { version = "0.3.0", path = "../rockbox-dsp" }
-rockbox-metadata = { version = "0.1.0", path = "../rockbox-metadata" }
-rockbox-playback = { version = "0.6.0", path = "../rockbox-playback", optional = true }
+rockbox-metadata = { version = "0.1.1", path = "../rockbox-metadata" }
+rockbox-playback = { version = "0.6.1", path = "../rockbox-playback", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rockbox-metadata/Cargo.toml
+++ b/crates/rockbox-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rockbox-metadata"
-version = "0.1.0"
+version = "0.1.1"
 description = "Audio file metadata / tag parser for 40+ formats (MP3, FLAC, Vorbis, Opus, MP4/AAC/ALAC, WavPack, APE, WMA, chiptunes, …) extracted from Rockbox"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/rockbox-metadata/vendor/metadata/mp4.c
+++ b/crates/rockbox-metadata/vendor/metadata/mp4.c
@@ -5,7 +5,6 @@
  *   Jukebox    |    |   (  <_> )  \___|    < | \_\ (  <_> > <  <
  *   Firmware   |____|_  /\____/ \___  >__|_ \|___  /\____/__/\_ \
  *                     \/            \/     \/    \/            \/
- * $Id$
  *
  * Copyright (C) 2005 Magnus Holmgren
  *
@@ -155,12 +154,35 @@ static unsigned int read_mp4_atom(int fd, uint32_t* size,
 
     if (*size == 1)
     {
-        /* FAT32 doesn't support files this big, so something seems to
-         * be wrong. (64-bit sizes should only be used when required.)
+        /* A size of 1 means the real length is a 64-bit value following the
+         * type field. Streaming encoders emit this for mdat because the
+         * payload length isn't known when the header is written, so it does
+         * not imply a file too big for the filesystem — read it and carry on.
+         * The header is 16 bytes here rather than 8.
          */
-        errno = EFBIG;
-        *type = 0;
-        return 0;
+        uint64_t largesize = 0;
+
+        read_uint64be(fd, &largesize);
+
+        if (largesize < 16 || (largesize - 16) > UINT32_MAX)
+        {
+            errno = EFBIG;
+            *type = 0;
+            return 0;
+        }
+
+        if (largesize > (uint64_t) size_left)
+        {
+            size_left = 0;
+        }
+        else
+        {
+            size_left -= (uint32_t) largesize;
+        }
+
+        *size = (uint32_t) (largesize - 16);
+
+        return size_left;
     }
 
     if (*size > 0)
@@ -636,8 +658,26 @@ static bool read_mp4_container(int fd, struct mp3entry* id3,
             break;
 
         case MP4_meta:
-            lseek(fd, 4, SEEK_CUR);  /* Skip version */
-            size -= 4;
+            /* ISO-BMFF declares `meta` a FullBox, so its payload starts with
+             * a zero version/flags word. QuickTime-flavoured files (Samsung
+             * recorders among them) omit it and start straight at the first
+             * child atom. Skipping unconditionally desynchronises the walk on
+             * those, so only skip when the word really is version/flags.
+             */
+            {
+                uint32_t version = 0;
+
+                read_uint32be(fd, &version);
+
+                if (version == 0)
+                {
+                    size -= 4;
+                }
+                else
+                {
+                    lseek(fd, -4, SEEK_CUR);
+                }
+            }
             /* Fall through */
 
         case MP4_moov:

--- a/crates/rockbox-playback/Cargo.toml
+++ b/crates/rockbox-playback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rockbox-playback"
-version = "0.6.0"
+version = "0.6.1"
 description = "Audio playback engine over rockbox-codecs + rockbox-dsp — native ReplayGain and Rockbox crossfade, with configurable output (cpal device, stdout, FIFO, Unix/TCP socket)"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -23,8 +23,8 @@ http = ["dep:reqwest", "dep:tempfile", "dep:quick-xml"]
 cpal = ["dep:cpal"]
 
 [dependencies]
-rockbox-metadata = { version = "0.1.0", path = "../rockbox-metadata" }
-rockbox-codecs = { version = "0.2.1", path = "../rockbox-codecs" }
+rockbox-metadata = { version = "0.1.1", path = "../rockbox-metadata" }
+rockbox-codecs = { version = "0.2.2", path = "../rockbox-codecs" }
 rockbox-dsp = { version = "0.3.0", path = "../rockbox-dsp" }
 cpal = { version = "0.15", optional = true }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/crates/rockbox-playback/examples/m4a_64bit_check.rs
+++ b/crates/rockbox-playback/examples/m4a_64bit_check.rs
@@ -1,0 +1,208 @@
+//! Validate MP4 handling for files that keep `moov` at EOF and/or use a
+//! 64-bit extended `mdat` size — the shape produced by streaming encoders
+//! (and served by plyr.fm).
+//!
+//! ```sh
+//! cargo run --release --example m4a_64bit_check -- <file-or-url> [more...]
+//! ```
+//!
+//! For each input it reports:
+//!   - the container shape (moov position, 32/64-bit atom sizes)
+//!   - the duration `rockbox_metadata` reports from the whole file
+//!   - the duration the engine derives over HTTP (header prefetch + tail retry)
+//!   - whether the codec actually decodes audio, and how much
+
+use std::io::{Read, Seek, SeekFrom};
+use std::time::Duration;
+
+use rockbox_playback::source::{id3v2_len, mp4_moov_extent, MediaSource};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let inputs: Vec<String> = std::env::args().skip(1).collect();
+    if inputs.is_empty() {
+        eprintln!("usage: m4a_64bit_check <file-or-url> [more...]");
+        std::process::exit(2);
+    }
+
+    let mut failures = 0;
+    for input in &inputs {
+        println!("\n=== {input} ===");
+        if let Err(e) = check(input) {
+            println!("  FAILED: {e}");
+            failures += 1;
+        }
+    }
+
+    println!("\n{} of {} input(s) failed", failures, inputs.len());
+    if failures > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn check(input: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let is_url = input.starts_with("http://") || input.starts_with("https://");
+
+    // Local copy so we can inspect the container and decode it.
+    let local = if is_url {
+        let tmp = std::env::temp_dir().join(format!(
+            "m4a_check_{}",
+            input.rsplit('/').next().unwrap_or("track.m4a")
+        ));
+        if !tmp.exists() {
+            let body = reqwest::blocking::Client::builder()
+                .user_agent("rockbox-playback/m4a-check")
+                .build()?
+                .get(input)
+                .send()?
+                .error_for_status()?
+                .bytes()?;
+            std::fs::write(&tmp, &body)?;
+        }
+        tmp
+    } else {
+        std::path::PathBuf::from(input)
+    };
+
+    describe_container(&local)?;
+
+    // 1. Whole-file metadata parse — exercises read_mp4_atom's 64-bit path.
+    let meta = rockbox_metadata::read(&local);
+    match &meta {
+        Ok(m) => println!(
+            "  metadata (whole file): duration={:?} rate={} Hz codec={:?}",
+            m.duration, m.sample_rate, m.codec
+        ),
+        Err(e) => println!("  metadata (whole file): FAILED — {e}"),
+    }
+    let file_duration = meta.as_ref().map(|m| m.duration).unwrap_or_default();
+    if file_duration.is_zero() {
+        return Err("metadata parse yielded no duration".into());
+    }
+
+    // 2. Decode for real — exercises libm4a's demuxer 64-bit path.
+    // The sink emits interleaved stereo i16 regardless of source layout.
+    let decoded = rockbox_codecs::decode_file_sync(&local)?;
+    let frames = decoded.pcm.len() / 2;
+    let decoded_secs = frames as f64 / decoded.sample_rate.max(1) as f64;
+    println!(
+        "  decoded: {} frames @ {} Hz = {:.2}s",
+        frames, decoded.sample_rate, decoded_secs
+    );
+    if frames == 0 {
+        return Err("codec produced no PCM".into());
+    }
+
+    // 3. The engine's HTTP path — header prefetch + tail retry.
+    if is_url {
+        match rockbox_playback::source::open_remote(input)? {
+            rockbox_playback::source::Remote::File(mut src) => {
+                const HEADER_BYTES: u64 = 512 * 1024;
+                const TAIL_BYTES: u64 = 1024 * 1024;
+                src.prefetch(HEADER_BYTES)?;
+                let size = src.size();
+                let mut m = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                let header_only = m.duration;
+                if m.duration.is_zero() && size > HEADER_BYTES {
+                    if let Some(tag_len) = id3v2_len(src.cache_path()) {
+                        let want = tag_len.saturating_add(256 * 1024).min(size);
+                        if want > HEADER_BYTES && src.prefetch_range(0, want).is_ok() {
+                            println!("  (widened header past {tag_len}-byte ID3v2 tag)");
+                            m = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                        }
+                    }
+                }
+                if m.duration.is_zero() && size > HEADER_BYTES {
+                    if let Some((start, end)) = mp4_moov_extent(&mut src) {
+                        println!("  (located moov at {start}..{end}, fetching exactly it)");
+                        src.prefetch_range(start, end)?;
+                        m = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                    }
+                }
+                if m.duration.is_zero() && size > HEADER_BYTES {
+                    let tail = size.saturating_sub(TAIL_BYTES).max(HEADER_BYTES);
+                    println!("  (falling back to {TAIL_BYTES}-byte tail)");
+                    src.prefetch_range(tail, size)?;
+                    m = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                }
+                println!(
+                    "  over HTTP: header-only={:?} after-tail-retry={:?} (size {} bytes)",
+                    header_only, m.duration, size
+                );
+                if m.duration.is_zero() {
+                    return Err("HTTP path still yielded no duration".into());
+                }
+                let drift = abs_diff(m.duration, file_duration);
+                if drift > Duration::from_millis(50) {
+                    return Err(format!(
+                        "HTTP duration {:?} disagrees with whole-file {:?}",
+                        m.duration, file_duration
+                    )
+                    .into());
+                }
+            }
+            _ => println!("  over HTTP: not a seekable file source"),
+        }
+    }
+
+    println!("  OK");
+    Ok(())
+}
+
+fn abs_diff(a: Duration, b: Duration) -> Duration {
+    if a > b {
+        a - b
+    } else {
+        b - a
+    }
+}
+
+/// Walk the top-level atoms and report where `moov` sits and whether any
+/// atom uses the 64-bit extended size form.
+fn describe_container(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let mut f = std::fs::File::open(path)?;
+    let size = f.metadata()?.len();
+    let mut pos = 0u64;
+    let mut order = Vec::new();
+    let mut ext64 = false;
+
+    while pos + 8 <= size && order.len() < 16 {
+        f.seek(SeekFrom::Start(pos))?;
+        let mut head = [0u8; 16];
+        if f.read(&mut head[..8])? < 8 {
+            break;
+        }
+        let short = u32::from_be_bytes(head[0..4].try_into().unwrap()) as u64;
+        let typ = String::from_utf8_lossy(&head[4..8]).to_string();
+        let (len, header) = if short == 1 {
+            ext64 = true;
+            if f.read(&mut head[8..16])? < 8 {
+                break;
+            }
+            (u64::from_be_bytes(head[8..16].try_into().unwrap()), 16)
+        } else if short == 0 {
+            (size - pos, 8)
+        } else {
+            (short, 8)
+        };
+        order.push(format!("{typ}@{pos}"));
+        if len < header {
+            break;
+        }
+        pos += len;
+    }
+
+    let moov_at = order.iter().position(|a| a.starts_with("moov"));
+    println!(
+        "  container: {} bytes, atoms [{}], 64-bit sizes: {}, moov: {}",
+        size,
+        order.join(" "),
+        if ext64 { "yes" } else { "no" },
+        match moov_at {
+            Some(0) => "first (faststart)".to_string(),
+            Some(i) => format!("index {i}"),
+            None => "at/after EOF scan — trailing".to_string(),
+        }
+    );
+    Ok(())
+}

--- a/crates/rockbox-playback/src/lib.rs
+++ b/crates/rockbox-playback/src/lib.rs
@@ -2324,8 +2324,7 @@ impl Engine {
                         if let Some(tag_len) = source::id3v2_len(src.cache_path()) {
                             let want = tag_len.saturating_add(256 * 1024).min(size);
                             if want > HEADER_BYTES && src.prefetch_range(0, want).is_ok() {
-                                meta = rockbox_metadata::read(src.cache_path())
-                                    .unwrap_or_default();
+                                meta = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
                             }
                         }
                     }
@@ -2338,8 +2337,7 @@ impl Engine {
                     if meta.duration.is_zero() && size > HEADER_BYTES {
                         if let Some((start, end)) = source::mp4_moov_extent(&mut src) {
                             if src.prefetch_range(start, end).is_ok() {
-                                meta = rockbox_metadata::read(src.cache_path())
-                                    .unwrap_or_default();
+                                meta = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
                             }
                         }
                     }
@@ -2975,7 +2973,6 @@ fn apply_replaygain_track(dsp: &mut rockbox_dsp::Dsp, meta: &Metadata) {
         rg.raw_album_peak,
     );
 }
-
 
 #[cfg(test)]
 mod insertion_tests {

--- a/crates/rockbox-playback/src/lib.rs
+++ b/crates/rockbox-playback/src/lib.rs
@@ -2308,13 +2308,49 @@ impl Engine {
                     // as soon as the header is present. ~512 KiB covers the
                     // format/rate/duration for the common codecs.
                     const HEADER_BYTES: u64 = 512 * 1024;
+                    const TAIL_BYTES: u64 = 1024 * 1024;
                     if src.prefetch(HEADER_BYTES).is_err() {
                         return Some(false);
                     }
                     let size = src.size();
                     // Parse tags/duration from the prefetched header (the cache
                     // file is full-size and sparse, so this reads what's there).
-                    let meta = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                    let mut meta = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                    // An MP3 can carry an ID3v2 tag (cover art) larger than the
+                    // header window, leaving the first MPEG frame — and the
+                    // Xing/VBR header that holds the duration — unfetched.
+                    // Extend the front past the tag and retry.
+                    if meta.duration.is_zero() && size > HEADER_BYTES {
+                        if let Some(tag_len) = source::id3v2_len(src.cache_path()) {
+                            let want = tag_len.saturating_add(256 * 1024).min(size);
+                            if want > HEADER_BYTES && src.prefetch_range(0, want).is_ok() {
+                                meta = rockbox_metadata::read(src.cache_path())
+                                    .unwrap_or_default();
+                            }
+                        }
+                    }
+                    // A non-faststart MP4 keeps `moov` at EOF, so the header
+                    // window can't reach it. Walk the atom chain to find the
+                    // box and fetch exactly it — a fixed tail guess misses the
+                    // ones whose `moov` is bigger than the guess. The parser
+                    // seeks over `mdat` rather than reading it, so header +
+                    // `moov` is enough and the hole between is never touched.
+                    if meta.duration.is_zero() && size > HEADER_BYTES {
+                        if let Some((start, end)) = source::mp4_moov_extent(&mut src) {
+                            if src.prefetch_range(start, end).is_ok() {
+                                meta = rockbox_metadata::read(src.cache_path())
+                                    .unwrap_or_default();
+                            }
+                        }
+                    }
+                    // Last resort for a container whose chain we can't walk:
+                    // take the tail and hope the trailer lives there.
+                    if meta.duration.is_zero() && size > HEADER_BYTES {
+                        let tail = size.saturating_sub(TAIL_BYTES).max(HEADER_BYTES);
+                        if src.prefetch_range(tail, size).is_ok() {
+                            meta = rockbox_metadata::read(src.cache_path()).unwrap_or_default();
+                        }
+                    }
                     let ext = src
                         .cache_path()
                         .extension()
@@ -2939,6 +2975,7 @@ fn apply_replaygain_track(dsp: &mut rockbox_dsp::Dsp, meta: &Metadata) {
         rg.raw_album_peak,
     );
 }
+
 
 #[cfg(test)]
 mod insertion_tests {

--- a/crates/rockbox-playback/src/source.rs
+++ b/crates/rockbox-playback/src/source.rs
@@ -64,7 +64,9 @@ impl MediaSource for FileSource {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "http")]
-pub use http::{open_remote, HttpSource, HttpStream, IcyInfo, Remote};
+pub use http::{
+    id3v2_len, mp4_moov_extent, open_remote, HttpSource, HttpStream, IcyInfo, Remote,
+};
 
 #[cfg(feature = "http")]
 mod http {
@@ -274,6 +276,17 @@ mod http {
             }
             self.pos = 0;
             Ok(())
+        }
+
+        /// Prefetch exactly `[start, end)` (clamped to the size) into the
+        /// cache, leaving the read cursor where it was. Used to pull a
+        /// trailer into view — a non-faststart MP4 keeps `moov` at EOF, so
+        /// the header window alone is not enough to parse its metadata.
+        pub fn prefetch_range(&mut self, start: u64, end: u64) -> io::Result<()> {
+            let pos = self.pos;
+            let result = self.ensure(start, end);
+            self.pos = pos;
+            result
         }
 
         /// Make sure `[start, end)` is present in the cache, fetching the
@@ -632,6 +645,93 @@ mod http {
             _ => return None,
         };
         Some(format!(".{ext}"))
+    }
+
+    /// Byte range `[start, end)` of the top-level `moov` box, found by walking
+    /// the MP4 atom chain over ranged reads.
+    ///
+    /// A non-faststart file keeps `moov` at EOF, out of reach of the header
+    /// prefetch; locating it exactly beats guessing a tail length, since the
+    /// box can be larger than any fixed guess. Returns `None` as soon as the
+    /// bytes stop looking like an atom chain, so calling it on a non-MP4 costs
+    /// one comparison and no extra fetch. Leaves the read cursor where it was.
+    pub fn mp4_moov_extent(src: &mut HttpSource) -> Option<(u64, u64)> {
+        let size = src.size();
+        let restore = src.stream_position().ok()?;
+        let mut pos = 0u64;
+        let mut found = None;
+
+        // Top-level chains are short (ftyp / free / mdat / moov); the cap is
+        // only there so a malformed file can't spin.
+        for _ in 0..16 {
+            if pos.saturating_add(8) > size || src.seek(SeekFrom::Start(pos)).is_err() {
+                break;
+            }
+
+            let mut head = [0u8; 16];
+            if src.read_exact(&mut head[..8]).is_err() {
+                break;
+            }
+            let short = u32::from_be_bytes([head[0], head[1], head[2], head[3]]) as u64;
+
+            let len = match short {
+                // Extended 64-bit size follows the type field.
+                1 => {
+                    if src.read_exact(&mut head[8..16]).is_err() {
+                        break;
+                    }
+                    u64::from_be_bytes([
+                        head[8], head[9], head[10], head[11], head[12], head[13], head[14],
+                        head[15],
+                    ])
+                }
+                // Zero means "to end of file".
+                0 => size - pos,
+                n => n,
+            };
+
+            if len < 8 || pos.saturating_add(len) > size {
+                break;
+            }
+            if &head[4..8] == b"moov" {
+                found = Some((pos, pos + len));
+                break;
+            }
+            pos += len;
+        }
+
+        let _ = src.seek(SeekFrom::Start(restore));
+        found
+    }
+
+    /// Total byte length of the ID3v2 tag at the start of `path`, header
+    /// included, or `None` when the file does not begin with one.
+    ///
+    /// The size is stored as four *syncsafe* bytes (7 bits each), and the
+    /// optional footer adds another 10. Used to widen the header prefetch: a
+    /// tag with embedded cover art can push the first MPEG frame — and the
+    /// Xing header the duration comes from — past the default window.
+    pub fn id3v2_len(path: &std::path::Path) -> Option<u64> {
+        let mut header = [0u8; 10];
+        std::fs::File::open(path)
+            .ok()?
+            .read_exact(&mut header)
+            .ok()?;
+
+        if &header[..3] != b"ID3" {
+            return None;
+        }
+        // A syncsafe integer never sets the high bit of any byte.
+        if header[6..10].iter().any(|b| b & 0x80 != 0) {
+            return None;
+        }
+
+        let size = header[6..10]
+            .iter()
+            .fold(0u64, |acc, &b| (acc << 7) | u64::from(b));
+        let footer = if header[5] & 0x10 != 0 { 10 } else { 0 };
+
+        Some(size + 10 + footer)
     }
 
     /// Extract a file extension (with dot) from a URL path so the temp cache

--- a/crates/rockbox-playback/src/source.rs
+++ b/crates/rockbox-playback/src/source.rs
@@ -64,9 +64,7 @@ impl MediaSource for FileSource {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "http")]
-pub use http::{
-    id3v2_len, mp4_moov_extent, open_remote, HttpSource, HttpStream, IcyInfo, Remote,
-};
+pub use http::{id3v2_len, mp4_moov_extent, open_remote, HttpSource, HttpStream, IcyInfo, Remote};
 
 #[cfg(feature = "http")]
 mod http {

--- a/lib/rbcodec/codecs/libm4a/demux.c
+++ b/lib/rbcodec/codecs/libm4a/demux.c
@@ -857,10 +857,25 @@ int qtmovie_read(stream_t *file, demux_res_t *demux_res)
             return 1;
         }
 
-        if (chunk_len == 1)
-            return 0;
-
         chunk_id = stream_read_uint32(qtmovie.stream);
+
+        if (chunk_len == 1)
+        {
+            /* The real length is a 64-bit value following the type field —
+             * common on mdat written by streaming encoders, which don't know
+             * the payload length up front. Every case below works in terms of
+             * "chunk_len - 8", and we have just consumed 8 extra header
+             * bytes, so normalise to the true length minus those 8.
+             */
+            uint64_t hi = stream_read_uint32(qtmovie.stream);
+            uint64_t lo = stream_read_uint32(qtmovie.stream);
+            uint64_t largesize = (hi << 32) | lo;
+
+            if (largesize < 16 || (largesize - 8) > (uint64_t) SIZE_MAX)
+                return 0;
+
+            chunk_len = (size_t) (largesize - 8);
+        }
 
         switch (chunk_id)
         {

--- a/lib/rbcodec/metadata/mp4.c
+++ b/lib/rbcodec/metadata/mp4.c
@@ -154,12 +154,35 @@ static unsigned int read_mp4_atom(int fd, uint32_t* size,
 
     if (*size == 1)
     {
-        /* FAT32 doesn't support files this big, so something seems to
-         * be wrong. (64-bit sizes should only be used when required.)
+        /* A size of 1 means the real length is a 64-bit value following the
+         * type field. Streaming encoders emit this for mdat because the
+         * payload length isn't known when the header is written, so it does
+         * not imply a file too big for the filesystem — read it and carry on.
+         * The header is 16 bytes here rather than 8.
          */
-        errno = EFBIG;
-        *type = 0;
-        return 0;
+        uint64_t largesize = 0;
+
+        read_uint64be(fd, &largesize);
+
+        if (largesize < 16 || (largesize - 16) > UINT32_MAX)
+        {
+            errno = EFBIG;
+            *type = 0;
+            return 0;
+        }
+
+        if (largesize > (uint64_t) size_left)
+        {
+            size_left = 0;
+        }
+        else
+        {
+            size_left -= (uint32_t) largesize;
+        }
+
+        *size = (uint32_t) (largesize - 16);
+
+        return size_left;
     }
 
     if (*size > 0)
@@ -635,8 +658,26 @@ static bool read_mp4_container(int fd, struct mp3entry* id3,
             break;
 
         case MP4_meta:
-            lseek(fd, 4, SEEK_CUR);  /* Skip version */
-            size -= 4;
+            /* ISO-BMFF declares `meta` a FullBox, so its payload starts with
+             * a zero version/flags word. QuickTime-flavoured files (Samsung
+             * recorders among them) omit it and start straight at the first
+             * child atom. Skipping unconditionally desynchronises the walk on
+             * those, so only skip when the word really is version/flags.
+             */
+            {
+                uint32_t version = 0;
+
+                read_uint32be(fd, &version);
+
+                if (version == 0)
+                {
+                    size -= 4;
+                }
+                else
+                {
+                    lseek(fd, -4, SEEK_CUR);
+                }
+            }
             /* Fall through */
 
         case MP4_moov:


### PR DESCRIPTION
Files whose moov sits at EOF, and/or whose mdat carries a 64-bit extended size, produced no duration and often failed to parse at all. Streaming encoders write both shapes because they don't know the payload length when the header goes out; ~65% of the m4a served by plyr.fm is affected, and the missing duration then reads downstream as "live stream, unknown length".

Three independent causes:

- read_mp4_atom() treated a size field of 1 as corruption ("FAT32 doesn't support files this big"). The extended size is a normal streaming artifact, not a large file — several affected files are under 2 MB. Read the 64-bit largesize and account for the 16-byte header.

- qtmovie_read() bailed on the same size field, so the codec could not demux these at all. Normalise chunk_len to the true length so every existing "chunk_len - 8" case keeps working.

- read_mp4_container() always skipped 4 bytes of version/flags on `meta`. ISO-BMFF declares it a FullBox, but QuickTime-flavoured writers omit the word and start at the first child, which desynchronised the walk before it reached `trak`. Only skip when the word really is zero.

On the engine side, the 512 KiB header prefetch cannot see a trailing moov, and .unwrap_or_default() silently turned that into duration 0. Walk the atom chain over ranged reads to locate moov exactly and fetch just that — a fixed tail guess misses boxes larger than the guess (one sampled file has a 1.24 MB moov). An MP3 whose ID3v2 art tag overflows the window gets the same treatment via its syncsafe length, and the tail heuristic stays as a last resort.

Validated against the live plyr.fm catalog: 57/58 m4a now report a duration matching ffprobe to within a second (the one failure is a 404 on the origin), plus 25 mixed-format tracks and 20 local library files with no regression. Existing suites pass.